### PR TITLE
More flexible substitutions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,7 +15,7 @@ def _substitute(url, html):
         try:
             for p in filter(lambda pattern: pattern in url, module.substitute):
                 for substitute in module.substitute[p]:
-                    target = re.sub(substitute[0], substitute[1], target)
+                    target = re.sub(substitute[0], substitute[1], target, flags=(re.DOTALL + re.I))
         except AttributeError:
             pass
     return target


### PR DESCRIPTION
Perform case-insensitive matching

Make the '.' special character match any  character at all, including a newline